### PR TITLE
add paramters label_number_right and label_number_left

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: You can make a beautiful volcano plot with just one line of code.
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.1
 Imports: 
     ggplot2,
     ggrepel,

--- a/man/add_regulate.Rd
+++ b/man/add_regulate.Rd
@@ -23,9 +23,6 @@ add_regulate(
 
 \item{fdr}{the threshold value of fdr.}
 }
-\value{
-
-}
 \description{
 Add regulate column to the DEG result
 }

--- a/man/ggvolcano.Rd
+++ b/man/ggvolcano.Rd
@@ -22,6 +22,8 @@ ggvolcano(
   add_label = TRUE,
   label = "row",
   label_number = 10,
+  label_number_left = NULL,
+  label_number_right = NULL,
   custom_label = NULL,
   output = TRUE,
   filename = "volcano_plot"
@@ -62,14 +64,15 @@ ggvolcano(
 
 \item{label_number}{how many gene labels you want to show in the plot.}
 
+\item{label_number_left}{how many gene labels you want to show in the left plot.}
+
+\item{label_number_right}{how many gene labels you want to show in the right plot.}
+
 \item{custom_label}{a vector containing your interest gene names that you want to add to the plot.}
 
 \item{output}{a logical value, whether to save the image, defult is TRUE.}
 
 \item{filename}{if the output = TRUE, please set a filename.}
-}
-\value{
-
 }
 \description{
 A volcano plot

--- a/man/gradual_volcano.Rd
+++ b/man/gradual_volcano.Rd
@@ -65,9 +65,6 @@ gradual_volcano(
 
 \item{filename}{if the output = TRUE, please set a filename.}
 }
-\value{
-
-}
 \description{
 A gradual volcano plot
 }

--- a/man/term_volcano.Rd
+++ b/man/term_volcano.Rd
@@ -76,9 +76,6 @@ term_volcano(
 
 \item{filename}{if the output = TRUE, please set a filename.}
 }
-\value{
-
-}
 \description{
 A term volcano plot
 }


### PR DESCRIPTION
你好：

我在你的代码上做了两个修改：

1）在legend上增加了上调和下调基因的数目
2）在标记基因的时候，可以规定在左边或者右边最top-n的基因，这样可以避免左右基因标记不平衡的问题。**label_number_right** 和 **label_number_left** 是两个新的参数，并且权限比**label_number**更高。

示例
```
data <- add_regulate(deg_data, log2FC_name = "log2FoldChange",
                     fdr_name = "padj",log2FC = 1, fdr = 0.05)


#show right only
ggvolcano(data, x = "log2FoldChange", y = "padj",
          label = "row", label_number = 5,
          label_number_right = 10,
          label_number_left = NULL
          , output = FALSE)
```
show right only
![1c5423dbaccecda52842c34ee02d500b](https://github.com/user-attachments/assets/75bbe4e6-1420-480a-bc11-cce3527cd0b8)

```
#show right and left top-n genes
ggvolcano(data, x = "log2FoldChange", y = "padj",
          label = "row", label_number = NULL,
          label_number_right = 10,
          label_number_left = 10
          , output = FALSE)
```

show right and left top-n genes
![77319da04be6ccb4014851ab065510e5](https://github.com/user-attachments/assets/4a67f382-d19f-4ef8-b8e3-7ab6b2cbb398)


